### PR TITLE
:bug: Fix invalid JSON in manifest.json

### DIFF
--- a/sketch-nudged.sketchplugin/Contents/Sketch/manifest.json
+++ b/sketch-nudged.sketchplugin/Contents/Sketch/manifest.json
@@ -1,31 +1,30 @@
 {
-  "name" : "Nudged",
-  "description" : "A Sketch plugin to easily edit your nudge distance settings.",
-  "version" : "1.0.1",
-  "author" : "Kevin Woodhouse",
-  "authorEmail" : "hello@kevinwoodhouse.com",
-  "homepage": "https://github.com/kevinwoodhouse/sketch-nudged",
-  "identifier" : "com.kevinwoodhouse.sketch-nudged",
-  "compatibleVersion": 4.1,
-  "bundleVersion": 1,
-  "commands" : [
-    {
-      "script" : "nudged.cocoascript",
-      "handler" : "settingsWindow",
-      "shortcut" : "alt cmd n",
-      "name" : "Nudged",
-      "identifier" : "Nudged",
-      "icon" : "nudged-icon-sr.png",
-      "description" : "Open Nudged - Edit nudge distance settings."
-    }
+	"name": "Nudged",
+	"description": "A Sketch plugin to easily edit your nudge distance settings.",
+	"version": "1.0.1",
+	"author": "Kevin Woodhouse",
+	"authorEmail": "hello@kevinwoodhouse.com",
+	"homepage": "https://github.com/kevinwoodhouse/sketch-nudged",
+	"identifier": "com.kevinwoodhouse.sketch-nudged",
+	"compatibleVersion": 4.1,
+	"bundleVersion": 1,
+	"commands": [{
+			"script": "nudged.cocoascript",
+			"handler": "settingsWindow",
+			"shortcut": "alt cmd n",
+			"name": "Nudged",
+			"identifier": "Nudged",
+			"icon": "nudged-icon-sr.png",
+			"description": "Open Nudged - Edit nudge distance settings."
+		}
 
-  ],
-  "menu" : {
-    "items" : [
-      "Nudged",
-    ],
+	],
+	"menu": {
+		"items": [
+			"Nudged"
+		],
 
-    "isRoot": true
-  },
+		"isRoot": true
+	}
 
 }


### PR DESCRIPTION
Sketchpacks Relay is quite strict on parsing only valid JSON for `manifest.json` files found within your plugin's repo.

This should fix the following errors as seen on jsonlint.com

```
Error: Parse error on line 24:
...": [			"Nudged",		],		"isRoot": true
---------------------^
Expecting 'STRING', 'NUMBER', 'NULL', 'TRUE', 'FALSE', '{', '[', got ']'
```

and

```
Error: Parse error on line 28:
..."isRoot": true	},}
--------------------^
Expecting 'STRING', got '}'
```

We'll check back on your indexed plugins to see if it successfully re-indexes your plugin with the correct data.